### PR TITLE
Use OpenSSL 1.1.1 instead of 1.0.2

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,13 +1,15 @@
 FROM amazonlinux
 
-RUN yum install openssl -y
+RUN yum install openssl11 -y
 RUN yum install zip -y
 RUN mkdir -p /tmp/layer
 
 CMD cd /tmp/layer && \
     mkdir -p bin && \
     mkdir -p lib && \
-    cp /bin/openssl ./bin && \
+    cp /bin/openssl11 ./bin/openssl && \
     cp /usr/lib64/libbz2.so.1 ./lib && \
+    cp /usr/lib64/libssl.so.1.1 ./lib && \
+    cp /usr/lib64/libcrypto.so.1.1 ./lib && \
     zip -r layer.zip ./* && \
     rm -rf lib bin

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -1,5 +1,5 @@
 const { execSync } = require('child_process')
 
 exports.handler = async(event, context) => {
-    execSync(' openssl genrsa -out testCert.key 2048', { encoding: 'utf8', stdio: 'inherit' })
+    execSync(' openssl genrsa 2048', { encoding: 'utf8', stdio: 'inherit' })
 }


### PR DESCRIPTION
This PR upgrades the openssl version from 1.0.2 to 1.1.1
It's unclear whether we want to only have a single layer (1.1.1) available, or keep the two version in two separate layers, to let the user decide, since there are breaking changes.

However, version 1.0.2 is [no longer supported by the project](https://www.openssl.org/policies/releasestrat.html)