### PR TITLE
Set explicit amazonlinux version instead of pulling the latest

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux
+FROM amazonlinux:2
 
 RUN yum install openssl11 -y
 RUN yum install zip -y


### PR DESCRIPTION
The latest Amazon Linux in the Dockerhub is the 2023 version, but Lambda is still using Amazon Linux 2. 